### PR TITLE
Ajuste na execução do script de teste

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,12 @@
-import type { Config } from 'jest';
-
-const config: Config = {
+// jest.config.js
+/** @type {import('jest').Config} */
+module.exports = {
   moduleFileExtensions: ['js', 'json', 'ts'],
   rootDir: 'src',
   testRegex: '.*\\.spec\\.ts$',
   transform: {
     '^.+\\.(t|j)s$': 'ts-jest',
   },
-  collectCoverage: true,
   coverageDirectory: '../coverage',
   coveragePathIgnorePatterns: [
     '/node_modules/',
@@ -26,5 +25,3 @@ const config: Config = {
   ],
   testEnvironment: 'node',
 };
-
-export default config;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:cov": "jest --config jest.config.ts --coverage",
+    "test:cov": "jest --config jest.config.js --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "NODE_ENV=test jest --config ./test/jest-e2e.json",
     "migration:generate:dev": "NODE_ENV=development ts-node -r tsconfig-paths/register node_modules/typeorm/cli.js migration:generate -d database/data-source.ts",
@@ -80,22 +80,5 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.20.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
## Descrição

## Número do ticket (issue) e link 

- [ISSUE-36 Erro na execução do script de teste](https://github.com/vieira-a/agro-manager/issues/36)

## Tipo de mudança

- [x] Bug fix (ajusta uma issue sem breaking change)
- [ ] Refactor (refactoring de uma issue sem breaking change)
- [ ] Nova feature (adiciona funcionalidade sem breaking change)
- [ ] Breaking change (ajusta ou cria funcionalidade que não funciona como esperado)
- [ ] Esta mudança requer atualizaçao de documentação

## Correções

- [x] Transformei `jest-config.ts` para `jest-config.js`para melhor compatibilidade com ambiente de produção e remover a necessidade de rodar o script de teste passando a flag `--config`
- [x] Removi a opção `collectCoverage` para evitar a coleta de cobertura de testes durante a execução no script de testes, visto que o script `test:cov` já traz essa informação
- [x] Removi a configuração do `jest` no arquivo `package.json` para evitar o erro de leitura de múltiplas configurações do Jest 