### PR TITLE
Adicionar RBAC (Role-Based Access Control) para diferentes níveis de usuário

### DIFF
--- a/database/migrations/1751309519122-AddRoleFieldToProducerTable.ts
+++ b/database/migrations/1751309519122-AddRoleFieldToProducerTable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddRoleFieldToProducerTable1751309519122 implements MigrationInterface {
+    name = 'AddRoleFieldToProducerTable1751309519122'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "producers" ADD "role" character varying NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "producers" DROP COLUMN "role"`);
+    }
+
+}

--- a/src/identity/application/service/__test__/identity-application.service.spec.ts
+++ b/src/identity/application/service/__test__/identity-application.service.spec.ts
@@ -15,6 +15,7 @@ describe('IdentityApplicationService', () => {
   const mockProducer = {
     getId: () => 'producer-id',
     getDocument: () => '09779679057',
+    getRole: () => 'user',
     getPassword: () => 'hashed-password',
   };
 

--- a/src/identity/application/service/identity-application.service.ts
+++ b/src/identity/application/service/identity-application.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ProducerApplicationService } from '../../../producer/application/service';
 import { PasswordFactory } from '../../../producer/domain/model/password.factory';
@@ -7,6 +7,14 @@ import {
   InvalidCredentialsException,
   InvalidTokenException,
 } from '../exception';
+import { ProducerRole } from '../../../producer/domain/enum/producer-role.enum';
+
+type TokenPayload = {
+  sub: string;
+  document: string;
+  role: string | ProducerRole;
+  type: 'access' | 'refresh';
+};
 
 @Injectable()
 export class IdentityApplicationService {
@@ -39,15 +47,17 @@ export class IdentityApplicationService {
     if (!isPasswordValid)
       throw new InvalidCredentialsException('Senha incorreta.');
 
-    const accessTokenPayload = {
+    const accessTokenPayload: TokenPayload = {
       sub: producer.getId(),
       document: producer.getDocument(),
+      role: producer.getRole(),
       type: 'access',
     };
 
-    const refreshTokenPayload = {
+    const refreshTokenPayload: TokenPayload = {
       sub: producer.getId(),
       document: producer.getDocument(),
+      role: producer.getRole(),
       type: 'refresh',
     };
 
@@ -74,15 +84,17 @@ export class IdentityApplicationService {
         throw new InvalidTokenException('Token inválido para refresh');
       }
 
-      const newAccessTokenPayload = {
+      const newAccessTokenPayload: TokenPayload = {
         sub: payload.sub,
         document: payload.document,
+        role: payload.role,
         type: 'access',
       };
 
-      const newRefreshTokenPayload = {
+      const newRefreshTokenPayload: TokenPayload = {
         sub: payload.sub,
         document: payload.document,
+        role: payload.role,
         type: 'refresh',
       };
 

--- a/src/identity/decorator/producer-role.decorator.ts
+++ b/src/identity/decorator/producer-role.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { ProducerRole } from '../../producer/domain/enum/producer-role.enum';
+
+export const PODUCER_ROLES_KEY = 'roles';
+export const ProducerRoles = (...roles: ProducerRole[]) =>
+  SetMetadata(PODUCER_ROLES_KEY, roles);

--- a/src/identity/guard/producer-roles.guard.ts
+++ b/src/identity/guard/producer-roles.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { ProducerRole } from '../../producer/domain/enum/producer-role.enum';
+import { PODUCER_ROLES_KEY } from '../decorator/producer-role.decorator';
+
+@Injectable()
+export class ProducerRolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<ProducerRole[]>(
+      PODUCER_ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!requiredRoles) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.some((role) => user.role === role);
+  }
+}

--- a/src/identity/web/rest/controller/__test__/authentication.e2e-spec.ts
+++ b/src/identity/web/rest/controller/__test__/authentication.e2e-spec.ts
@@ -4,9 +4,10 @@ import * as request from 'supertest';
 import { AppModule } from '../../../../../app.module';
 import { startPostgresContainer } from '../../../../../../test/utils/postgres-container';
 import * as cookieParser from 'cookie-parser';
-import { CreateProducerRequest } from 'src/producer/web/rest/dto/request';
+import { CreateProducerRequest } from '../../../../../producer/web/rest/dto/request';
 import { cleanDatabase } from '../../../../../../test/utils/clean-database';
 import { DataSource } from 'typeorm';
+import { ProducerRole } from '../../../../../producer/domain/enum/producer-role.enum';
 
 describe('AuthenticationController (e2e)', () => {
   let app: INestApplication;
@@ -18,6 +19,7 @@ describe('AuthenticationController (e2e)', () => {
   const validPayload: CreateProducerRequest = {
     document: '71663081093',
     name: 'Darth Vader',
+    role: ProducerRole.PRODUCER_USER,
     password: 'P@ssword10',
     passwordConfirmation: 'P@ssword10',
     farm: {

--- a/src/producer/application/dto/create-producer.dto.ts
+++ b/src/producer/application/dto/create-producer.dto.ts
@@ -1,8 +1,10 @@
+import { ProducerRole } from '../../../producer/domain/enum/producer-role.enum';
 import { CreateFarmDto } from './create-farm.dto';
 
 export class CreateProducerDto {
   readonly document: string;
   readonly name: string;
+  readonly role: ProducerRole;
   readonly password: string;
   readonly passwordConfirmation: string;
   readonly farm?: CreateFarmDto;

--- a/src/producer/application/service/__test__/producer-application-service.spec.ts
+++ b/src/producer/application/service/__test__/producer-application-service.spec.ts
@@ -16,6 +16,7 @@ import { PasswordFactory } from '../../../../producer/domain/model/password.fact
 import { Password } from '../../../../producer/domain/model/password';
 import { PasswordNotMatchException } from '../../exception/password-not-match.exception';
 import { InvalidPasswordException } from '../../../../producer/domain/exception/invalid-password.exception';
+import { ProducerRole } from '../../../../producer/domain/enum/producer-role.enum';
 
 describe('ProducerApplicationService', () => {
   let service: ProducerApplicationService;
@@ -50,6 +51,7 @@ describe('ProducerApplicationService', () => {
 
   const validProducer: CreateProducerDto = {
     name: 'João da Silva',
+    role: ProducerRole.PRODUCER_USER,
     document: '09779679057',
     password: 'P@ssword10',
     passwordConfirmation: 'P@ssword10',
@@ -90,6 +92,7 @@ describe('ProducerApplicationService', () => {
   it('should create a producer with only name and document', async () => {
     const input: CreateProducerDto = {
       name: 'João da Silva',
+      role: ProducerRole.PRODUCER_USER,
       document: '09779679057',
       password: 'P@ssword10',
       passwordConfirmation: 'P@ssword10',

--- a/src/producer/application/service/producer-application.service.ts
+++ b/src/producer/application/service/producer-application.service.ts
@@ -43,6 +43,7 @@ export class ProducerApplicationService {
     const producer = Producer.create({
       document: producerDocument,
       name: input.name,
+      role: input.role,
       password: hashedPassword,
     });
 

--- a/src/producer/domain/enum/producer-role.enum.ts
+++ b/src/producer/domain/enum/producer-role.enum.ts
@@ -1,0 +1,4 @@
+export enum ProducerRole {
+  PRODUCER_ADMIN = 'producer_admin',
+  PRODUCER_USER = 'producer_user',
+}

--- a/src/producer/domain/model/producer.ts
+++ b/src/producer/domain/model/producer.ts
@@ -4,10 +4,12 @@ import { CNPJ } from './cnpj';
 import { InvalidProducerParamException } from '../exception';
 import { Farm } from './farm';
 import { Password } from './password';
+import { ProducerRole } from '../enum/producer-role.enum';
 
 type ProducerProps = {
   document: CPF | CNPJ;
   name: string;
+  role: ProducerRole;
   password: Password;
   farms?: Farm[];
 };
@@ -19,6 +21,7 @@ export class Producer {
     private readonly id: string,
     private readonly document: CPF | CNPJ,
     private name: string,
+    private role: ProducerRole,
     private password: Password,
   ) {}
 
@@ -29,6 +32,7 @@ export class Producer {
       randomUUID(),
       props.document,
       name,
+      props.role,
       props.password,
     );
 
@@ -48,6 +52,7 @@ export class Producer {
       props.id,
       props.document,
       props.name,
+      props.role,
       props.password,
     );
 

--- a/src/producer/domain/model/producer.ts
+++ b/src/producer/domain/model/producer.ts
@@ -84,6 +84,10 @@ export class Producer {
     return this.name;
   }
 
+  getRole(): ProducerRole {
+    return this.role;
+  }
+
   getPassword(): string {
     return this.password.getHashedValue();
   }

--- a/src/producer/infrastructure/persistence/entity/producer.entity.ts
+++ b/src/producer/infrastructure/persistence/entity/producer.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
 import { FarmEntity } from './farm.entity';
+import { ProducerRole } from 'src/producer/domain/enum/producer-role.enum';
 
 @Entity({ name: 'producers' })
 export class ProducerEntity {
@@ -8,6 +9,9 @@ export class ProducerEntity {
 
   @Column()
   name: string;
+
+  @Column()
+  role: ProducerRole;
 
   @Column()
   document: string;

--- a/src/producer/infrastructure/persistence/entity/producer.entity.ts
+++ b/src/producer/infrastructure/persistence/entity/producer.entity.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
 import { FarmEntity } from './farm.entity';
-import { ProducerRole } from 'src/producer/domain/enum/producer-role.enum';
+import { ProducerRole } from '../../../../producer/domain/enum/producer-role.enum';
 
 @Entity({ name: 'producers' })
 export class ProducerEntity {

--- a/src/producer/infrastructure/persistence/mapper/producer.mapper.ts
+++ b/src/producer/infrastructure/persistence/mapper/producer.mapper.ts
@@ -13,6 +13,7 @@ export class ProducerMapper {
     entity.id = domain.getId();
     entity.document = domain.getDocument();
     entity.name = domain.getName();
+    entity.role = domain.getRole();
     entity.password = domain.getPassword();
     entity.farms = domain.getFarms().map(FarmMapper.toEntity);
     return entity;
@@ -26,6 +27,7 @@ export class ProducerMapper {
     return Producer.restore({
       id: entity.id,
       name: entity.name,
+      role: entity.role,
       document,
       farms,
       password: new Password(entity.password),
@@ -37,6 +39,7 @@ export class ProducerMapper {
       id: domain.getId(),
       document: domain.getDocument(),
       name: domain.getName(),
+      role: domain.getRole(),
       farms: domain.getFarms().map((farm) => FarmMapper.toResponse(farm)),
     };
   }

--- a/src/producer/web/rest/controller/__test__/producer.e2e-spec.ts
+++ b/src/producer/web/rest/controller/__test__/producer.e2e-spec.ts
@@ -8,6 +8,7 @@ import { cleanDatabase } from '../../../../../../test/utils/clean-database';
 import * as cookieParser from 'cookie-parser';
 import { CreateProducerRequest } from '../../dto/request';
 import * as jwt from 'jsonwebtoken';
+import { ProducerRole } from '../../../../../producer/domain/enum/producer-role.enum';
 
 describe('ProducerController (e2e)', () => {
   let app: INestApplication;
@@ -18,6 +19,7 @@ describe('ProducerController (e2e)', () => {
   const validPayload: CreateProducerRequest = {
     document: '71663081093',
     name: 'Darth Vader',
+    role: ProducerRole.PRODUCER_USER,
     password: 'P@ssword10',
     passwordConfirmation: 'P@ssword10',
     farm: {

--- a/src/producer/web/rest/controller/producer.controller.ts
+++ b/src/producer/web/rest/controller/producer.controller.ts
@@ -27,6 +27,8 @@ import { ApiProducerResponse } from '../dto/response/api-producer.response';
 import { DashBoardResponse } from '../dto/response/dashboard.response';
 import { Logger } from 'nestjs-pino';
 import { ProducerJwtAuthGuard } from '../guard/producer-jwt-auth.guard';
+import { ProducerRoles } from '../../../../identity/decorator/producer-role.decorator';
+import { ProducerRole } from '../../../../producer/domain/enum/producer-role.enum';
 @Controller('producers')
 export class ProducerController {
   constructor(
@@ -58,6 +60,7 @@ export class ProducerController {
     );
   }
 
+  @ProducerRoles(ProducerRole.PRODUCER_ADMIN)
   @Delete(':id')
   @ApiParam({ name: 'id', type: String, description: 'ID do produtor' })
   @HttpCode(HttpStatus.NO_CONTENT)

--- a/src/producer/web/rest/dto/request/create-producer.request.ts
+++ b/src/producer/web/rest/dto/request/create-producer.request.ts
@@ -10,6 +10,7 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
+import { ProducerRole } from '../../../../../producer/domain/enum/producer-role.enum';
 
 export class CreateCropRequest {
   @ApiProperty({ example: 'Milho' })
@@ -113,6 +114,11 @@ export class CreateProducerRequest {
   @IsNotEmpty()
   @IsString()
   name: string;
+
+  @ApiProperty({ example: 'admin | user' })
+  @IsNotEmpty()
+  @IsString()
+  role: ProducerRole;
 
   @ApiProperty({ type: CreateFarmRequest })
   @IsOptional()

--- a/src/producer/web/rest/dto/response/producer.response.ts
+++ b/src/producer/web/rest/dto/response/producer.response.ts
@@ -49,6 +49,9 @@ export class ProducerResponse {
   @ApiProperty({ example: 'João Silva' })
   name: string;
 
+  @ApiProperty({ example: 'producer_admin | producer_role' })
+  role: string;
+
   @ApiProperty({ type: [FarmResponse] })
   farms: FarmResponse[];
 }


### PR DESCRIPTION
## Descrição

## Número do ticket (issue) e link 

- [ISSUE-23 Adicionar RBAC (Role-Based Access Control) para diferentes níveis de usuário](https://github.com/vieira-a/agro-manager/issues/26)

## Tipo de mudança

- [ ] Bug fix (ajusta uma issue sem breaking change)
- [ ] Refactor (refactoring de uma issue sem breaking change)
- [x] Nova feature (adiciona funcionalidade sem breaking change)
- [ ] Breaking change (ajusta ou cria funcionalidade que não funciona como esperado)
- [ ] Esta mudança requer atualizaçao de documentação

**Implementações**

- [x] Adicionar decorator ProducerRoles para controle de acesso de administradores no endpoint de deleção de produtores.
- [x] Adicionar ProducerRoles e ProducerRolesGuard para controle de acesso baseado em papéis (roles).
- [x] Adicionar tratamento de papéis (roles) no IdentityApplicationService e atualizar testes de autenticação.
- [x] Implementar autenticação JWT com tokens de refresh e gerenciamento de papéis (roles).
- [x] Adicionar migrations para o novo campo criado.
- [x] Adicionar propriedade role ao CreateProducerDto e integrá-la ao modelo, entidade e mapper de Producer.
- [x] Integrar o ProducerRole nos testes de criação de produtor.
- [x] Adicionar enum ProducerRole e integrá-lo ao modelo de Producer.

**Testes**

- [x] Aplicadas as alterações necessárias nos testes unitários e e2e para garantir o funcionamento do novo campo